### PR TITLE
Dadah89/raw list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 gem "bump"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       tzinfo
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bump (0.3.9)
     diff-lcs (1.1.3)

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ To get a basic subset of translations you can simply pass the locale.
 
     Cldr::Timezones.list(:es) # {"Europe/Moscow" => "(GMT+04:00) Moscú"}
     Cldr::Timezones.list(:ja) #	{"America/Cordoba" => "（GMT-09:00）モスクワ"}
-    
+
 There is also support for fallback.
 
     Cldr::Timezones.list(:"es-MX") # {"Europe/Moscow" => "(GMT+04:00) Moscú"}
@@ -24,6 +24,10 @@ There is also support for fallback.
 If you want to retrieve the full set of timezones (currently 581) you can simply pass the option ```:full```
 
     Cldr::Timezones.list(:ja, :full) #To get the full list of timezones
+
+If you want to get a list which contains the translated name, offset and GMT translation and format for each translation (supports :full option, i.e. `:pt, :full`)
+
+    Cldr::Timezones.raw(:ja) # {"America/Cordoba" => ["コルドバ", "+08:00", "GMT"]
 
 If you want to get the list of supported languages
 
@@ -34,9 +38,6 @@ TODO
 - Handle BIDI timezones
 
     ```Cldr::Timezones.list(:ar) # {"America/Cordoba" => "0}جرينتش} كوردوبا"}```
-- Handle method raw which will return translated name, offset and GMT translation and format
-
-    ```Cldr::Timezones.raw(:ja)  # {"America/Cordoba" => ["コルドバ", "+08:00", "GMT"]}```
 
 Author
 ======

--- a/spec/cldr_timezones_spec.rb
+++ b/spec/cldr_timezones_spec.rb
@@ -6,6 +6,47 @@ describe Cldr::Timezones do
     Cldr::Timezones::VERSION.should =~ /^[\.\da-z]+$/
   end
 
+  describe ".list" do
+    it "raises error if not locale is passed" do
+      expect{Cldr::Timezones.list(nil)}.to raise_error(ArgumentError, "Locale cannot be blank")
+    end
+
+    it "builds a list with translations" do
+      timezones = Cldr::Timezones.list(:es)
+      timezones["Europe/Moscow"].should match(/\(GMT\+0\d:00\) Moscú/)
+      timezones["America/Sao_Paulo"].should match(/\(GMT-0\d:00\) São Paulo/)
+    end
+
+    it "builds a list with translations" do
+      timezones = Cldr::Timezones.list(:"es-MX", true)
+      timezones["America/Indiana/Knox"].should match(/\(GMT-0\d:00\) Knox, Indiana/)
+      timezones["Asia/Saigon"].should match(/\(GMT\+0\d:00\) Ho Chi Minh/)
+    end
+
+    # Checks that fallback is working since Moscú is only in "es"
+    it "builds a list with translations using fallback" do
+      timezones = Cldr::Timezones.list(:"es-MX")
+      timezones["Europe/Moscow"].should match(/\(GMT\+0\d:00\) Moscú/)
+      timezones["America/Sao_Paulo"].should match(/\(GMT-0\d:00\) São Paulo/)
+    end
+
+    it "builds a list with translations using fallback en-US" do
+      timezones = Cldr::Timezones.list(:"en-US")
+      timezones["Europe/Moscow"].should match(/\(GMT\+0\d:00\) Moscow/)
+      timezones["America/Sao_Paulo"].should match(/\(GMT-0\d:00\) Sao Paulo/)
+    end
+
+    it "builds a list with meaningful subset" do
+      timezones = Cldr::Timezones.list(:ja)
+      timezones.size.should equal(124)
+    end
+
+    it "builds the complete set if true is passed" do
+      timezones = Cldr::Timezones.list(:ja, true)
+      timezones.size.should equal(581)
+    end
+  end
+
   describe ".raw" do
     it "builds a list with translations" do
       timezones = Cldr::Timezones.raw(:pt)
@@ -25,47 +66,6 @@ describe Cldr::Timezones do
       timezones["America/Sao_Paulo"][0].should eq("São Paulo")
       timezones["America/Sao_Paulo"][1].should match(/\-0\d:00/)
       timezones["America/Sao_Paulo"][2].should eq("GMT")
-    end
-  end
-
-  describe ".list" do
-    it "raises error if not locale is passed" do
-      expect{Cldr::Timezones.list(nil)}.to raise_error(ArgumentError, "Locale cannot be blank")
-    end
-
-    it "builds a list with translations" do
-      timezones = Cldr::Timezones.list(:es)
-      timezones["Europe/Moscow"].should eq("(GMT+04:00) Moscú")
-      timezones["America/Sao_Paulo"].should eq("(GMT-02:00) São Paulo")
-    end
-
-    it "builds a list with translations" do
-      timezones = Cldr::Timezones.list(:"es-MX", true)
-      timezones["America/Indiana/Knox"].should eq("(GMT-06:00) Knox, Indiana")
-      timezones["Asia/Saigon"].should eq("(GMT+07:00) Ho Chi Minh")
-    end
-
-    # Checks that fallback is working since Moscú is only in "es"
-    it "builds a list with translations using fallback" do
-      timezones = Cldr::Timezones.list(:"es-MX")
-      timezones["Europe/Moscow"].should eq("(GMT+04:00) Moscú")
-      timezones["America/Sao_Paulo"].should eq("(GMT-02:00) São Paulo")
-    end
-
-    it "builds a list with translations using fallback en-US" do
-      timezones = Cldr::Timezones.list(:"en-US")
-      timezones["Europe/Moscow"].should eq("(GMT+04:00) Moscow")
-      timezones["America/Sao_Paulo"].should eq("(GMT-02:00) Sao Paulo")
-    end
-
-    it "builds a list with meaningful subset" do
-      timezones = Cldr::Timezones.list(:ja)
-      timezones.size.should equal(124)
-    end
-
-    it "builds the complete set if true is passed" do
-      timezones = Cldr::Timezones.list(:ja, true)
-      timezones.size.should equal(581)
     end
   end
 

--- a/spec/cldr_timezones_spec.rb
+++ b/spec/cldr_timezones_spec.rb
@@ -6,6 +6,28 @@ describe Cldr::Timezones do
     Cldr::Timezones::VERSION.should =~ /^[\.\da-z]+$/
   end
 
+  describe ".raw" do
+    it "builds a list with translations" do
+      timezones = Cldr::Timezones.raw(:pt)
+      timezones["Europe/Moscow"][0].should eq("Moscou")
+      timezones["Europe/Moscow"][1].should match(/\+0\d:00/)
+      timezones["Europe/Moscow"][2].should eq("GMT")
+      timezones["America/Sao_Paulo"][0].should eq("São Paulo")
+      timezones["America/Sao_Paulo"][1].should match(/\-0\d:00/)
+      timezones["America/Sao_Paulo"][2].should eq("GMT")
+    end
+
+    it "builds a list with translations using fallback" do
+      timezones = Cldr::Timezones.raw(:"es-MX")
+      timezones["Europe/Moscow"][0].should eq("Moscú")
+      timezones["Europe/Moscow"][1].should match(/\+0\d:00/)
+      timezones["Europe/Moscow"][2].should eq("GMT")
+      timezones["America/Sao_Paulo"][0].should eq("São Paulo")
+      timezones["America/Sao_Paulo"][1].should match(/\-0\d:00/)
+      timezones["America/Sao_Paulo"][2].should eq("GMT")
+    end
+  end
+
   describe ".list" do
     it "raises error if not locale is passed" do
       expect{Cldr::Timezones.list(nil)}.to raise_error(ArgumentError, "Locale cannot be blank")


### PR DESCRIPTION
Implements `Cldr::Timezones.raw`:

``` ruby
Cldr::Timezones.raw('pt-BR')['America/Sao_Paulo']
#  => ["São Paulo", "-03:00", "GMT"]
```

Also fixed few tests that started failing because offset changed for some timezones:

![Screen Shot 2013-03-10 at 10 58 12 PM](https://f.cloud.github.com/assets/697824/242471/548dca38-8a11-11e2-8ada-e5574a623d7c.png)

@anamartinez what do you think?
